### PR TITLE
Add headerbar ui plugin

### DIFF
--- a/plugins/ddb_misc_headerbar_GTK3/manifest.json
+++ b/plugins/ddb_misc_headerbar_GTK3/manifest.json
@@ -1,0 +1,25 @@
+{
+    source: {
+        type: "git",
+        url: "https://github.com/saivert/ddb_misc_headerbar_GTK3.git",
+        patches: [
+        ],
+    },
+    make: {
+        type: "autotools",
+        bootstrap: "./autogen.sh",
+        root: "/",
+        ENV: {
+            GTK_DEPS_CFLAGS: "$GTK310_CFLAGS",
+            GTK_DEPS_LIBS: "$GTK310_LIBS",
+            GLIB_DEPS_CFLAGS: "",
+            GLIB_DEPS_LIBS: "",
+            GIO_DEPS_CFLAGS: "",
+            GIO_DEPS_LIBS: ""
+        },
+        out: [
+            "src/.libs/ddb_misc_headerbar_GTK3.so",
+        ],
+    }
+}
+


### PR DESCRIPTION
Tested on Ubuntu 17.10 builds and packs plugin.
plugin-builder need consideration for GTK3 only plugins as it invokes pluginfo for GTK2.
