### PR TITLE
Windows: add msbuild support (+smtc plugin) 🎉 

### DIFF
--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -9,10 +9,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
     - name: Install msys2
       uses: msys2/setup-msys2@v2
       with:
         update: true
+        path-type: inherit
         install: >-
           mingw-w64-x86_64-toolchain mingw-w64-x86_64-libzip mingw-w64-x86_64-pkg-config mingw-w64-x86_64-dlfcn
           git make tar unzip xz zip mingw-w64-x86_64-clang mingw-w64-x86_64-libblocksruntime

--- a/build
+++ b/build
@@ -318,6 +318,9 @@ for my $package (@packages) {
         system ("cd $ROOT/$manifest->{make}->{root}; make clean") if $conf_use_cached_src;
         system ("cd $ROOT/$manifest->{make}->{root}; make") && die "make finished with an error\n";
     }
+    elsif ($manifest->{make}->{type} eq 'msbuild') {
+        system ("cd $ROOT/$manifest->{make}->{root}; MSYS2_ARG_CONV_EXCL=* powershell msbuild /m /p:Configuration=Release .") && die "msbuild finished with an error\n";
+    }
     else {
         die "make type '$manifest->{make}->{type}' is not supported\n";
     }

--- a/plugins/ddb_smtc/manifest.json
+++ b/plugins/ddb_smtc/manifest.json
@@ -1,0 +1,14 @@
+{
+    supported_platforms: ['windows'],
+    source: {
+        type: "git",
+        url: "https://github.com/DeaDBeeF-for-Windows/ddb_smtc",
+    },
+    make: {
+        type: "msbuild",
+        root: "/",
+        out: [
+            "x64/Release/ddb_smtc.dll"
+        ]
+    }
+}


### PR DESCRIPTION
EDIT:
It is first plugin that does not get compiled on Linux which means that `build-html` will not see it. I think the best way to fix that is to have plugin descriptors cached after each os build job and move `build-html` to another job that depends on these. Eventually artifacts could be used to pass the descriptors.

EDIT 2:
From documentation I read that cache cannot be shared across different systems...