### PR TITLE
Update Dockerfile, fix Docker build

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:16.04
 
 RUN apt-get -qq update
-RUN apt-get install -y -qq autopoint automake autoconf intltool libc6-dev-i386 libc6-dev yasm perl wget g++-multilib zip bzip2 git mercurial subversion make libtool pkg-config libglib2.0-bin libgtk-3.0 libpulse0
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -qq autopoint automake autoconf intltool libc6-dev yasm libglib2.0-bin perl wget zip bzip2 make libtool pkg-config fakeroot clang openssh-client rsync git gcc g++ fontconfig xorg libharfbuzz0b libthai0 libwrap0 libsndfile1 libasyncns0 libjson0-dev

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+mkdir -p docker-artifacts
 docker build -t deadbeef-plugin-builder . || exit 1
 docker run --rm -v ${PWD}/docker-artifacts:/usr/src/deadbeef/temp deadbeef-plugin-builder


### PR DESCRIPTION
Two changes:

- Syncs the Dockerfile up closer with GitHub Actions, adding missing dependencies, setting `DEBIAN_FRONTEND=noninteractive`, and changing to use the `ubuntu:16.04` tag instead of the `ubuntu:trusty` tag (for good measure, since it's what the GitHub Action uses.)

- Adds a `mkdir -p docker-artifacts` to ensure the directory exists. On my system it appeared to be necessary to do this.