### PR TITLE
Update build_html job for new download-artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
             DEBIAN_FRONTEND=noninteractive apt-get install -y -qq autopoint automake autoconf intltool libc6-dev yasm libglib2.0-bin perl wget zip bzip2 make libtool pkg-config fakeroot clang openssh-client rsync git gcc g++ fontconfig xorg libharfbuzz0b libthai0 libwrap0 libsndfile1 libasyncns0 libjson0-dev &&
             sed -i 's/mozilla\/DST_Root_CA_X3\.crt/\!mozilla\/DST_Root_CA_X3\.crt/' /etc/ca-certificates.conf &&
             update-ca-certificates &&
-            TRAVIS_OS_NAME=linux travis/build.sh &&
+            TRAVIS_OS_NAME=linux gh_ed25519_key= gh_ed25519_iv= travis/build.sh &&
             TRAVIS_OS_NAME=linux travis/upload.sh
           "
       env:
@@ -96,35 +96,27 @@ jobs:
     name: HTML update build
     needs: [build_linux, build_windows, build_macos]
     runs-on: ubuntu-latest
-    container: ubuntu:16.04
     steps:
-    - name: Install dependencies for Linux
-      run: |
-        apt-get -qq update
-        apt-get install -y -qq perl wget zip bzip2 openssh-client rsync git gcc g++
     - name: Checkout for Linux
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Download macOS plugin descriptors
-      uses: actions/download-artifact@v3
+    - name: Download plugin descriptors
+      uses: actions/download-artifact@v4
       with:
-        name: plug-descr-mac
+        pattern: plug-descr-*
         path: temp/output/x86_64
-    - name: Download Windows plugin descriptors
-      uses: actions/download-artifact@v3
+        merge-multiple: true
+    - name: Build and Upload HTML
+      uses: docker://ubuntu:16.04
       with:
-        name: plug-descr-win
-        path: temp/output/x86_64
-    - name: Download Linux plugin descriptors
-      uses: actions/download-artifact@v3
-      with:
-        name: plug-descr-linux
-        path: temp/output/x86_64
-    - name: Build HTML
-      run: TRAVIS_OS_NAME=linux travis/build_html.sh
-    - name: Upload HTML
+        args: |
+          /bin/bash -c "
+            apt-get -qq update &&
+            apt-get install -y -qq perl wget zip bzip2 openssh-client rsync git gcc g++ &&
+            TRAVIS_OS_NAME=linux gh_ed25519_key= gh_ed25519_iv= travis/build_html.sh &&
+            TRAVIS_OS_NAME=linux travis/upload_html.sh
+          "
       env:
           gh_ed25519_key: ${{ secrets.GH_ENCRYPTED_ED25519_KEY }}
           gh_ed25519_iv: ${{ secrets.GH_ENCRYPTED_ED25519_IV }}
-      run: TRAVIS_OS_NAME=linux travis/upload_html.sh


### PR DESCRIPTION
There's room for improvement, but this ought to work.

Also force-clears the value of `gh_ed25519_key` and `gh_ed25519_iv` during the build segments since otherwise it would be available to the build scripts.