### PR TITLE
Ensure deps aren't downloaded on each Docker build

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -3,9 +3,11 @@ case "$TRAVIS_OS_NAME" in
         STATICDEPS_URL="http://sourceforge.net/projects/deadbeef/files/staticdeps/ddb-static-deps-latest.tar.bz2/download"
         mkdir -p temp
         if [ ! -d static-deps ]; then
+            if [ ! -f temp/ddb-static-deps.tar.bz2 ]; then
+                echo "downloading static deps..."
+                wget -q $STATICDEPS_URL -O temp/ddb-static-deps.tar.bz2 || exit 1
+            fi
             mkdir static-deps
-            echo "downloading static deps..."
-            wget -q $STATICDEPS_URL -O temp/ddb-static-deps.tar.bz2 || exit 1
             echo "unpacking static deps..."
             tar jxf temp/ddb-static-deps.tar.bz2 -C static-deps || exit 1
         fi


### PR DESCRIPTION
- In the Docker setup, `ddb-static-deps.tar.bz2` is downloaded to `/usr/src/deadbeef/temp/ddb-static-deps.tar.bz2`.
- This location is mounted to `docker-artifacts`, so it should not be necessary to download it every time a local build is kicked off.
- However, the check that currently guards this looks for the `/usr/src/deadbeef/static-deps` folder, which is _not_ mounted outside of the container, and thus is not persisted between runs.
- This additional condition should prevent needlessly downloading `ddb-static-deps.tar.bz2` on every `docker-build.sh` run.