### PR TITLE
Add deadbeef-pxtone

### DIFF
--- a/plugins/deadbeef-pxtone/manifest.json
+++ b/plugins/deadbeef-pxtone/manifest.json
@@ -1,0 +1,20 @@
+{
+    supported_platforms: ['linux','windows'],
+    source: {
+        type: "git",
+        url: "https://github.com/jchv/deadbeef-pxtone.git"
+    },
+    make: {
+        type: "make",
+        ENV: {
+            "EXTRA_LDFLAGS": "-lvorbisfile -lvorbis -logg"
+        },
+        root: "",
+        out: [
+            "pxtone.so"
+        ],
+    },
+    metadata: {
+        "webpage": "https://github.com/jchv/deadbeef-pxtone"
+    }
+}


### PR DESCRIPTION
This is a plugin that plays pxtone Collage projects. It has a similar feature set and design to my other DeaDBeeF plugin, deadbeef-vgmstream, and as such the build process is also relatively simple.

There is one workaround: I need to double the libraries in the linker flags, otherwise `ov_clear` inappropriately gets discarded by the linker. This doesn't make any sense to me since the `-lvorbisfile` should already appear after the object file that needs `ov_clear`, and it doesn't seem necessary on a newer linker. I'm guessing it's either a bug in the linker or vorbisfile is missing pkg-config files in the old version of Ubuntu.